### PR TITLE
Currently the Cloud Formation Script ( github.com/pivo...master/pcf.json...

### DIFF
--- a/pcf.json
+++ b/pcf.json
@@ -179,7 +179,7 @@
     },
     "OpsMgrAMI": {
       "Type": "String",
-      "Default": "ami-fa5b6792",
+      "Default": "ami-36030c5e",
       "Description": "Enter Ops Manager AMI"
     },
 


### PR DESCRIPTION
...) has the Old AMI (ami-fa5b6792) which is no longer available.

OpsMgrAMI": {
     "Type": "String",
     "Default": "ami-fa5b6792",
     "Description": "Enter Ops Manager AMI"

The pcf.json should be updated with the 1.4.1.0 AMI (ami­36030c5e) as noted in Pivotal network .
